### PR TITLE
PRC-507: Address phones bug on get organisation.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/mapping/OrganisationAddressDetailsMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/mapping/OrganisationAddressDetailsMappers.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.organisationsapi.model.response.Organisation
 import uk.gov.justice.digital.hmpps.organisationsapi.model.response.OrganisationAddressPhoneDetails
 
 fun OrganisationAddressDetailsEntity.toModel(
-  phoneNumbers: List<Pair<OrganisationAddressPhoneEntity, OrganisationPhoneDetailsEntity>>,
+  phoneNumbers: List<Pair<OrganisationAddressPhoneEntity, OrganisationPhoneDetailsEntity?>>,
 ): OrganisationAddressDetails = OrganisationAddressDetails(
   organisationAddressId = organisationAddressId,
   organisationId = organisationId,
@@ -35,21 +35,24 @@ fun OrganisationAddressDetailsEntity.toModel(
   specialNeedsCodeDescription = specialNeedsCodeDescription,
   contactPersonName = contactPersonName,
   businessHours = businessHours,
-  phoneNumbers = phoneNumbers.map { (addressPhoneEntity, phoneEntity) ->
-    OrganisationAddressPhoneDetails(
-      organisationAddressPhoneId = addressPhoneEntity.organisationAddressPhoneId,
-      organisationPhoneId = phoneEntity.organisationPhoneId,
-      organisationAddressId = organisationAddressId,
-      organisationId = phoneEntity.organisationId,
-      phoneType = phoneEntity.phoneType,
-      phoneTypeDescription = phoneEntity.phoneTypeDescription,
-      phoneNumber = phoneEntity.phoneNumber,
-      extNumber = phoneEntity.extNumber,
-      createdBy = phoneEntity.createdBy,
-      createdTime = phoneEntity.createdTime,
-      updatedBy = phoneEntity.updatedBy,
-      updatedTime = phoneEntity.updatedTime,
-    )
+  phoneNumbers = phoneNumbers.mapNotNull { (addressPhoneEntity, phoneEntity) ->
+    when {
+      phoneEntity != null -> OrganisationAddressPhoneDetails(
+        organisationAddressPhoneId = addressPhoneEntity.organisationAddressPhoneId,
+        organisationPhoneId = phoneEntity.organisationPhoneId,
+        organisationAddressId = organisationAddressId,
+        organisationId = phoneEntity.organisationId,
+        phoneType = phoneEntity.phoneType,
+        phoneTypeDescription = phoneEntity.phoneTypeDescription,
+        phoneNumber = phoneEntity.phoneNumber,
+        extNumber = phoneEntity.extNumber,
+        createdBy = phoneEntity.createdBy,
+        createdTime = phoneEntity.createdTime,
+        updatedBy = phoneEntity.updatedBy,
+        updatedTime = phoneEntity.updatedTime,
+      )
+      else -> null
+    }
   },
   createdBy = createdBy,
   createdTime = createdTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/integration/resource/GetOrganisationByOrganisationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/integration/resource/GetOrganisationByOrganisationIdIntegrationTest.kt
@@ -101,6 +101,19 @@ class GetOrganisationByOrganisationIdIntegrationTest : SecureApiIntegrationTestB
             ).setCreatedAndModified(),
           ),
         ).setCreatedAndModified(),
+        MigrateOrganisationAddress(
+          nomisAddressId = RandomUtils.secure().randomLong(),
+          type = "BUS",
+          primaryAddress = false,
+          mailAddress = false,
+          serviceAddress = false,
+          noFixedAddress = false,
+          locality = "locality",
+          postCode = "D2 2DN",
+          startDate = LocalDate.of(2020, 3, 3),
+          endDate = LocalDate.of(2021, 4, 4),
+          phoneNumbers = emptyList(),
+        ).setCreatedAndModified(),
       ),
     ).setCreatedAndModified()
 
@@ -158,7 +171,7 @@ class GetOrganisationByOrganisationIdIntegrationTest : SecureApiIntegrationTestB
         assertThat(updatedBy).isEqualTo("MODIFIED")
         assertThat(updatedTime).isEqualTo(LocalDateTime.of(2020, 3, 4, 11, 45))
       }
-      assertThat(addresses).hasSize(1)
+      assertThat(addresses).hasSize(2)
       with(addresses[0]) {
         assertThat(addressType).isEqualTo("BUS")
         assertThat(addressTypeDescription).isEqualTo("Business address")
@@ -199,6 +212,13 @@ class GetOrganisationByOrganisationIdIntegrationTest : SecureApiIntegrationTestB
           assertThat(updatedBy).isEqualTo("MODIFIED")
           assertThat(updatedTime).isEqualTo(LocalDateTime.of(2020, 3, 4, 11, 45))
         }
+      }
+      with(addresses[1]) {
+        // Making sure phone numbers are propagated across ALL addresses for this organisation
+        assertThat(phoneNumbers).isEmpty()
+        assertThat(postcode).isEqualTo("D2 2DN")
+        assertThat(startDate).isEqualTo(LocalDate.of(2020, 3, 3))
+        assertThat(endDate).isEqualTo(LocalDate.of(2021, 4, 4))
       }
     }
   }


### PR DESCRIPTION
Fixes a bug where all addresses included the phone numbers for all other addresses in this organisation.
The mapping between organisation address phones and organisation phones was not quite strict enough.

I am now thinking that the simpler, and clearer, solution for address-phones is to hold them separately (for both contacts and organisations) from global phones. So we'd have `organisation-global-phones` and `organisation-address-phones` as distinct tables, each containing the phone-type, phone-number and ext-number, plus the audit columns. The problem at the moment is that there is no simple way to get JUST the global phone numbers, as to do so, we need to get all phone numbers and then filter out the address-specific phone numbers, which leads to complexity and lack of clarity in the code, which I think is unnecessary.
