### PR TITLE
PRC-587 - Change to PagedModel and fix multi sort

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/facade/OrganisationFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/facade/OrganisationFacade.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.organisationsapi.facade
 
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PagedModel
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.organisationsapi.model.request.CreateOrganisationRequest
 import uk.gov.justice.digital.hmpps.organisationsapi.model.request.OrganisationSearchRequest
@@ -28,5 +28,5 @@ class OrganisationFacade(
 
   fun getOrganisationSummaryById(organisationId: Long): OrganisationSummary = organisationService.getOrganisationSummaryById(organisationId)
 
-  fun search(request: OrganisationSearchRequest, pageable: Pageable): Page<OrganisationSummary> = organisationService.search(request, pageable)
+  fun search(request: OrganisationSearchRequest, pageable: Pageable): PagedModel<OrganisationSummary> = organisationService.search(request, pageable)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/mapping/OrganisationSummaryEntityMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/mapping/OrganisationSummaryEntityMappers.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.organisationsapi.mapping
 
 import org.springframework.data.domain.Page
+import org.springframework.data.web.PagedModel
 import uk.gov.justice.digital.hmpps.organisationsapi.entity.OrganisationSummaryEntity
 import uk.gov.justice.digital.hmpps.organisationsapi.model.response.OrganisationSummary
 
@@ -23,4 +24,4 @@ fun OrganisationSummaryEntity.toModel(): OrganisationSummary = OrganisationSumma
   businessPhoneNumberExtension = this.businessPhoneNumberExtension,
 )
 
-fun Page<OrganisationSummaryEntity>.toModel(): Page<OrganisationSummary> = map { it.toModel() }
+fun Page<OrganisationSummaryEntity>.toModel(): PagedModel<OrganisationSummary> = PagedModel(map { it.toModel() })

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/model/response/OrganisationSummaryResultItemPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/model/response/OrganisationSummaryResultItemPage.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.organisationsapi.model.response
-
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
-
-// This is not directly used but is required to make Swagger produce a spec with page and content fields typed correctly
-class OrganisationSummaryResultItemPage(content: List<OrganisationSummary>, pageable: Pageable, total: Long) : PageImpl<OrganisationSummary>(content, pageable, total)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/repository/MapDomainToEntityForSort.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/repository/MapDomainToEntityForSort.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.organisationsapi.repository
+
+import jakarta.validation.ValidationException
+import uk.gov.justice.digital.hmpps.organisationsapi.entity.OrganisationSummaryEntity
+import uk.gov.justice.digital.hmpps.organisationsapi.model.response.OrganisationSummary
+
+fun mapSortPropertiesOfOrgSearch(property: String): String = when (property) {
+  OrganisationSummary::organisationId.name -> OrganisationSummaryEntity::organisationId.name
+  OrganisationSummary::organisationName.name -> OrganisationSummaryEntity::organisationName.name
+  OrganisationSummary::organisationActive.name -> OrganisationSummaryEntity::organisationActive.name
+  OrganisationSummary::flat.name -> OrganisationSummaryEntity::flat.name
+  OrganisationSummary::property.name -> OrganisationSummaryEntity::property.name
+  OrganisationSummary::street.name -> OrganisationSummaryEntity::street.name
+  OrganisationSummary::area.name -> OrganisationSummaryEntity::area.name
+  OrganisationSummary::cityCode.name -> OrganisationSummaryEntity::cityCode.name
+  OrganisationSummary::cityDescription.name -> OrganisationSummaryEntity::cityDescription.name
+  OrganisationSummary::countyCode.name -> OrganisationSummaryEntity::countyCode.name
+  OrganisationSummary::countyDescription.name -> OrganisationSummaryEntity::countyDescription.name
+  OrganisationSummary::postcode.name -> OrganisationSummaryEntity::postCode.name
+  OrganisationSummary::countryCode.name -> OrganisationSummaryEntity::countryCode.name
+  OrganisationSummary::countryDescription.name -> OrganisationSummaryEntity::countryDescription.name
+  OrganisationSummary::businessPhoneNumber.name -> OrganisationSummaryEntity::businessPhoneNumber.name
+  OrganisationSummary::businessPhoneNumberExtension.name -> OrganisationSummaryEntity::businessPhoneNumberExtension.name
+  else -> throw ValidationException("Unable to sort on $property")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/repository/OrganisationSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/repository/OrganisationSearchRepository.kt
@@ -59,12 +59,13 @@ class OrganisationSearchRepository(
     entity: Root<OrganisationSummaryEntity>,
   ) {
     if (pageable.sort.isSorted) {
-      pageable.sort.forEach {
+      val sortable = pageable.sort.map {
         when {
-          it.isAscending -> cq.orderBy(cb.asc(entity.get<String>(it.property)))
-          else -> cq.orderBy(cb.desc(entity.get<String>(it.property)))
+          it.isAscending -> cb.asc(entity.get<String>(it.property))
+          else -> cb.desc(entity.get<String>(it.property))
         }
-      }
+      }.toList()
+      cq.orderBy(sortable)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/resource/OrganisationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/resource/OrganisationController.kt
@@ -12,6 +12,7 @@ import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort.Direction
 import org.springframework.data.web.PageableDefault
+import org.springframework.data.web.PagedModel
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -28,7 +29,6 @@ import uk.gov.justice.digital.hmpps.organisationsapi.model.request.CreateOrganis
 import uk.gov.justice.digital.hmpps.organisationsapi.model.request.OrganisationSearchRequest
 import uk.gov.justice.digital.hmpps.organisationsapi.model.response.OrganisationDetails
 import uk.gov.justice.digital.hmpps.organisationsapi.model.response.OrganisationSummary
-import uk.gov.justice.digital.hmpps.organisationsapi.model.response.OrganisationSummaryResultItemPage
 import uk.gov.justice.digital.hmpps.organisationsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
@@ -137,12 +137,6 @@ class OrganisationController(private val organisationFacade: OrganisationFacade)
       ApiResponse(
         responseCode = "200",
         description = "Organisations searched successfully. There may be no results.",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = OrganisationSummaryResultItemPage::class),
-          ),
-        ],
       ),
       ApiResponse(
         responseCode = "400",
@@ -160,5 +154,5 @@ class OrganisationController(private val organisationFacade: OrganisationFacade)
     @Parameter(description = "Pageable configurations", required = false)
     @PageableDefault(sort = ["organisationName"], direction = Direction.ASC)
     pageable: Pageable,
-  ) = organisationFacade.search(request, pageable)
+  ): PagedModel<OrganisationSummary> = organisationFacade.search(request, pageable)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/resource/sync/SyncOrganisationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/resource/sync/SyncOrganisationController.kt
@@ -10,10 +10,10 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springdoc.core.annotations.ParameterObject
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort.Direction
 import org.springframework.data.web.PageableDefault
+import org.springframework.data.web.PagedModel
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -200,5 +200,5 @@ class SyncOrganisationController(val syncFacade: SyncFacade) {
     @ParameterObject
     @PageableDefault(sort = ["organisationId"], size = 100, direction = Direction.ASC)
     pageable: Pageable,
-  ): Page<SyncOrganisationId> = syncFacade.getIds(pageable)
+  ): PagedModel<SyncOrganisationId> = PagedModel(syncFacade.getIds(pageable))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/service/OrganisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/service/OrganisationService.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.organisationsapi.service
 
 import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PagedModel
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.organisationsapi.entity.OrganisationAddressPhoneEntity
 import uk.gov.justice.digital.hmpps.organisationsapi.entity.OrganisationEntity
@@ -89,7 +89,7 @@ class OrganisationService(
       )
     }
 
-  fun search(request: OrganisationSearchRequest, pageable: Pageable): Page<OrganisationSummary> = organisationSearchRepository.search(request, pageable).toModel()
+  fun search(request: OrganisationSearchRequest, pageable: Pageable): PagedModel<OrganisationSummary> = organisationSearchRepository.search(request, pageable).toModel()
 
   @Transactional
   fun create(request: CreateOrganisationRequest): OrganisationDetails {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/integration/helper/TestAPIClient.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.organisationsapi.integration.helper
 
+import org.springframework.data.web.PagedModel
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
@@ -211,44 +212,11 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
 
   data class OrganisationSearchResponse(
     val content: List<OrganisationSummary>,
-    val pageable: ReturnedPageable,
-    val last: Boolean,
-    val totalPages: Int,
-    val totalElements: Int,
-    val first: Boolean,
-    val size: Int,
-    val number: Int,
-    val sort: ReturnedSort,
-    val numberOfElements: Int,
-    val empty: Boolean,
-  )
-
-  data class ReturnedPageable(
-    val pageNumber: Int,
-    val pageSize: Int,
-    val sort: ReturnedSort,
-    val offset: Int,
-    val unpaged: Boolean,
-    val paged: Boolean,
-  )
-
-  data class ReturnedSort(
-    val empty: Boolean,
-    val unsorted: Boolean,
-    val sorted: Boolean,
+    val page: PagedModel.PageMetadata,
   )
 
   data class OrganisationIdsResponse(
     val content: List<SyncOrganisationId>,
-    val pageable: ReturnedPageable,
-    val last: Boolean,
-    val totalPages: Int,
-    val totalElements: Int,
-    val first: Boolean,
-    val size: Int,
-    val number: Int,
-    val sort: ReturnedSort,
-    val numberOfElements: Int,
-    val empty: Boolean,
+    val page: PagedModel.PageMetadata,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/integration/resource/OrganisationSearchIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/integration/resource/OrganisationSearchIntegrationTest.kt
@@ -44,7 +44,7 @@ class OrganisationSearchIntegrationTest : SecureApiIntegrationTestBase() {
   @ValueSource(strings = ["ROLE_ORGANISATIONS__R", "ROLE_ORGANISATIONS__RW"])
   fun `should return empty list if no organisation found and work with all roles`(role: String) {
     val response = testAPIClient.searchOrganisations(OrganisationSearchRequest("ABC"))
-    assertThat(response.empty).isTrue()
+    assertThat(response.page.totalElements).isEqualTo(0)
     assertThat(response.content).isEmpty()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/integration/resource/sync/SyncOrganisationsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/integration/resource/sync/SyncOrganisationsIntegrationTest.kt
@@ -241,20 +241,20 @@ class SyncOrganisationsIntegrationTest : PostgresIntegrationTestBase() {
 
       val firstPage = testAPIClient.syncReconcileOrganisations(0, 2)
       with(firstPage) {
-        assertThat(totalElements).isGreaterThanOrEqualTo(3)
+        assertThat(page.totalElements).isGreaterThanOrEqualTo(3)
         assertThat(content.hasSize(2))
         assertThat(content).extracting("organisationId").hasSize(2)
       }
 
       val secondPage = testAPIClient.syncReconcileOrganisations(1, 2)
       with(secondPage) {
-        assertThat(totalElements).isGreaterThanOrEqualTo(3)
+        assertThat(page.totalElements).isGreaterThanOrEqualTo(3)
         assertThat(content.size).isGreaterThanOrEqualTo(1)
       }
 
       val bigPage = testAPIClient.syncReconcileOrganisations(0, 100)
       with(bigPage) {
-        assertThat(totalElements).isGreaterThanOrEqualTo(3)
+        assertThat(page.totalElements).isGreaterThanOrEqualTo(3)
         assertThat(content.size).isGreaterThanOrEqualTo(3)
         assertThat(content).extracting("organisationId").containsAll(listOf(5005L, 5006L, 5007L))
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/repository/MapDomainToEntityForSortKtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/repository/MapDomainToEntityForSortKtTest.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.organisationsapi.repository
+
+import jakarta.validation.ValidationException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.organisationsapi.entity.OrganisationSummaryEntity
+import uk.gov.justice.digital.hmpps.organisationsapi.model.response.OrganisationSummary
+import kotlin.reflect.full.memberProperties
+
+class MapDomainToEntityForSortKtTest {
+
+  @Test
+  fun `can map contact search result item fields to contact with address entity fields`() {
+    OrganisationSummary::class.memberProperties.forEach { property ->
+      val mapped = mapSortPropertiesOfOrgSearch(property.name)
+      assertThat(mapped).isNotNull()
+      assertThat(OrganisationSummaryEntity::class.memberProperties.find { it.name == mapped }).isNotNull()
+    }
+  }
+
+  @Test
+  fun `attempting to sort on an invalid field for contact search gives an error`() {
+    val expected = org.junit.jupiter.api.assertThrows<ValidationException> {
+      mapSortPropertiesOfOrgSearch("foo")
+    }
+    assertThat(expected.message).isEqualTo("Unable to sort on foo")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/resource/OrganisationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/resource/OrganisationControllerTest.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PagedModel
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.organisationsapi.facade.OrganisationFacade
 import uk.gov.justice.digital.hmpps.organisationsapi.model.request.CreateOrganisationRequest
@@ -100,7 +101,7 @@ class OrganisationControllerTest {
       // Given
       val request = OrganisationSearchRequest("foo")
       val params = Pageable.ofSize(99)
-      val expectedResults = PageImpl<OrganisationSummary>(emptyList())
+      val expectedResults = PagedModel(PageImpl<OrganisationSummary>(emptyList()))
       whenever(organisationFacade.search(request, params)).thenReturn(expectedResults)
 
       // When


### PR DESCRIPTION
Org search was only sorting by the final parameter. Also made a breaking change to paged responses to use PagedModel rather than serialising PageImpl as Spring now warns that this is unsupported.