### PR TITLE
PRC-642: Update org summary address selection

### DIFF
--- a/src/main/resources/migrations/common/R__v_organisation_summary.sql
+++ b/src/main/resources/migrations/common/R__v_organisation_summary.sql
@@ -23,14 +23,22 @@ SELECT o.organisation_id,
        op.phone_number AS business_phone_number,
        op.ext_number AS business_phone_number_extension
 FROM organisation o
- LEFT JOIN organisation_address oa ON oa.organisation_id = o.organisation_id AND primary_address = TRUE
- LEFT JOIN organisation_phone op ON op.organisation_phone_id = (
+ LEFT JOIN organisation_address oa ON oa.organisation_address_id = (
+    SELECT organisation_address_id FROM organisation_address oa1
+    WHERE oa1.organisation_id = o.organisation_id
+      AND oa1.end_date IS NULL
+    ORDER BY oa1.primary_address DESC, oa1.mail_address DESC, oa1.start_date DESC NULLS LAST, oa1.created_time DESC
+    LIMIT 1
+)
+LEFT JOIN organisation_phone op ON op.organisation_phone_id = (
       SELECT op1.organisation_phone_id
       FROM organisation_phone op1
+      JOIN organisation_address oa2 ON oa2.organisation_id = o.organisation_id
       JOIN organisation_address_phone oap
-        ON oap.organisation_address_id = oa.organisation_address_id AND
+        ON oap.organisation_address_id = oa2.organisation_address_id AND
            oap.organisation_phone_id = op1.organisation_phone_id
       WHERE op1.phone_type = 'BUS'
+        AND oa2.primary_address = TRUE
       LIMIT 1
     )
  LEFT JOIN reference_codes city_ref ON city_ref.group_code = 'CITY' AND city_ref.code = oa.city_code

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/integration/resource/GetOrganisationSummaryByOrganisationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/organisationsapi/integration/resource/GetOrganisationSummaryByOrganisationIdIntegrationTest.kt
@@ -91,7 +91,7 @@ class GetOrganisationSummaryByOrganisationIdIntegrationTest : SecureApiIntegrati
           businessHours = "9-5",
           comment = "Comments",
           startDate = LocalDate.of(2020, 2, 3),
-          endDate = LocalDate.of(2021, 3, 4),
+          endDate = null,
           phoneNumbers = listOf(
             MigrateOrganisationPhoneNumber(
               nomisPhoneId = RandomUtils.secure().randomLong(),


### PR DESCRIPTION
Now follows similar logic to contact and prisoner addresses. The address must not have an end date, then it's primary, or mail address if no primary address, or most recent start date if no primary or mail address.

Phone number remains as business phone number of the primary address only.